### PR TITLE
fix: update collector tag in example

### DIFF
--- a/examples/traces/demo/docker-compose.yml
+++ b/examples/traces/demo/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       OTEL_SERVICE_NAME: service-three
 
   collector:
-    image: otel/opentelemetry-collector-contrib:0.39.0
+    image: otel/opentelemetry-collector-contrib
     volumes:
       - './collector:/etc/otel'
     ports:


### PR DESCRIPTION
Follow-up from #1383. Debug exporter isn't available until v0.86.0, so this new configuration throws an error when trying to run the collector. `Error: cannot unmarshal the configuration: unknown exporters type "debug" for "debug"`.

Instead of setting to v0.86.0, I noticed the other docker-compose files (e.g. [docker-compose.collector.yaml](https://github.com/open-telemetry/opentelemetry-php/blob/main/docker-compose.collector.yaml)) omitted the tag which looks to pull in latest. I just updated this to match.